### PR TITLE
Issue with MySQL

### DIFF
--- a/djorm_pool/__init__.py
+++ b/djorm_pool/__init__.py
@@ -18,6 +18,36 @@ if settings.DEBUG:
 
 POOL_SETTINGS = getattr(settings, 'DJORM_POOL_OPTIONS', {})
 
+
+class hashabledict(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
+
+
+class hashablelist(list):
+    def __hash__(self):
+        return hash(tuple(sorted(self)))
+
+
+class ManagerProxy(object):
+    def __init__(self, manager):
+        self.manager = manager
+
+    def __getattr__(self, key):
+        return getattr(self.manager, key)
+
+    def connect(self, *args, **kwargs):
+        if 'conv' in kwargs:
+            conv = kwargs['conv']
+            if isinstance(conv, dict):
+                items = []
+                for k, v in conv.items():
+                    if isinstance(v, list):
+                        v = hashablelist(v)
+                    items.append((k, v))
+                kwargs['conv'] = hashabledict(items)
+        return self.manager.connect(*args, **kwargs)
+
 try:
     from django.db.backends.postgresql_psycopg2 import base as pgsql_base
     pgsql_base._Database = pgsql_base.Database
@@ -29,7 +59,8 @@ except ImproperlyConfigured:
 try:
     from django.db.backends.mysql import base as mysql_base
     mysql_base._Database = mysql_base.Database
-    mysql_base.Database = manage(mysql_base._Database, **POOL_SETTINGS)
+    db = ManagerProxy(manage(mysql_base._Database, **POOL_SETTINGS))
+    mysql_base.Database = db
 except ImproperlyConfigured:
     pass
 


### PR DESCRIPTION
While trying to use this with MySQL, I was getting a strange traceback from sqlalchemy.

```
Traceback (most recent call last):
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 88, in inner_run
    self.validate(display_num_errors=True)
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/core/management/base.py", line 249, in validate
    num_errors = get_validation_errors(s, app)
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/core/management/validation.py", line 102, in get_validation_errors
    connection.validation.validate_field(e, opts, f)
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/db/backends/mysql/validation.py", line 14, in validate_field
    db_version = self.connection.get_server_version()
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/db/backends/mysql/base.py", line 338, in get_server_version
    self.cursor()
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/db/backends/__init__.py", line 250, in cursor
    cursor = self.make_debug_cursor(self._cursor())
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/django/db/backends/mysql/base.py", line 322, in _cursor
    self.connection = Database.connect(**kwargs)
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/sqlalchemy/pool.py", line 1010, in connect
    return self.get_pool(*args, **kw).connect()
  File "/Users/jeethu/Envs/bb/lib/python2.7/site-packages/sqlalchemy/pool.py", line 981, in get_pool
    return self.pools[key]
TypeError: unhashable type: 'dict'
```

This is because `MySQLdb.connections.Connection` takes an optional `conv` parameter which is a dictionary of [converters](http://mysql-python.sourceforge.net/MySQLdb-1.2.2/public/MySQLdb.converters-module.html).
This makes the connection parameters unhashable, and thus the error.
Here's a very hacky fix for this issue.
