### PR TITLE
Add ssl connection support [MYSQL]

### DIFF
--- a/djorm_pool/__init__.py
+++ b/djorm_pool/__init__.py
@@ -72,6 +72,15 @@ def patch_mysql():
                             v = hashablelist(v)
                         items.append((k, v))
                     kwargs['conv'] = hashabledict(items)
+            if 'ssl' in kwargs:
+                ssl = kwargs['ssl']
+                if isinstance(ssl, dict):
+                    items = []
+                    for k, v in ssl.items():
+                        if isinstance(v, list):
+                            v = hashablelist(v)
+                        items.append((k, v))
+                    kwargs['ssl'] = hashabledict(items)
             return self.manager.connect(*args, **kwargs)
 
     try:


### PR DESCRIPTION
This make pool works when adding SSL support to DATABASES:
Mysql SSL config sample:
DATABASES = {
'default':{
...
   'OPTIONS': {
            'ssl': {
                'ca': PROJECT_PATH + '/certs/ca.pem',
                'cert': PROJECT_PATH + '/certs/cert.pem',
                'key': PROJECT_PATH + '/certs/key.pem'
            },
        }
}
